### PR TITLE
feat: lock an auth token for a few minutes

### DIFF
--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -18,11 +18,20 @@ AuthorizerOAuth2.prototype.authorize = AuthorizerOAuth2.prototype.whoami = funct
     if (err) return cb(err)
     else if (!user.accessToken) return _this.session.oauthURL(cb, token)
     else {
-      _this._checkToken(user.accessToken, function (err) {
-        if (err) {
-          return _this.session.oauthURL(cb, token)
-        } else {
+      // we hold a lock in redis for a few minutes, to prevent
+      // a thundering herd of auth requests.
+      _this.session.checkLock(token, function (locked) {
+        if (locked) {
           return cb(null, user)
+        } else {
+          _this._checkToken(user.accessToken, function (err) {
+            if (err) {
+              return _this.session.oauthURL(cb, token)
+            } else {
+              _this.session.lock(token)
+              return cb(null, user)
+            }
+          })
         }
       })
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -5,6 +5,8 @@ var redis = require('redis')
 function SessionOAuth2 (opts) {
   _.extend(this, {
     sessionLookupPrefix: 'user-',
+    sessionLockPrefix: 'user-token-lock-',
+    lockTime: 300,
     client: redis.createClient(process.env.LOGIN_CACHE_REDIS),
     clientId: process.env.OAUTH2_CLIENT_ID,
     clientSecret: process.env.OAUTH2_CLIENT_SECRET,
@@ -41,12 +43,39 @@ SessionOAuth2.prototype.get = function (key, cb) {
   })
 }
 
+SessionOAuth2.prototype.checkLock = function (key, cb) {
+  var _this = this
+
+  key = normalizeKey(key)
+
+  this.client.get(_this.sessionLockPrefix + key, function (_err, lock) {
+    if (lock) return cb(true)
+    else return cb(false)
+  })
+}
+
 SessionOAuth2.prototype.set = function (key, user, cb) {
   var _this = this
 
   key = normalizeKey(key)
 
   _this.client.set(this.sessionLookupPrefix + key, JSON.stringify(user), cb)
+}
+
+SessionOAuth2.prototype.lock = function (key) {
+  var _this = this
+
+  key = normalizeKey(key)
+
+  _this.client.setex(this.sessionLockPrefix + key, this.lockTime, 'locked')
+}
+
+SessionOAuth2.prototype.unlock = function (key) {
+  var _this = this
+
+  key = normalizeKey(key)
+
+  _this.client.del(this.sessionLockPrefix + key)
 }
 
 SessionOAuth2.prototype.delete = function (key, cb) {

--- a/test/authorizer.js
+++ b/test/authorizer.js
@@ -17,6 +17,31 @@ tap.test('it responds with session object if SSO dance is complete', function (t
     .get('/user')
     .reply(200)
 
+  session.unlock('ben@example.com-abc123')
+
+  session.set('ben@example.com-abc123', userComplete, function (err) {
+    t.equal(err, null)
+    authorizer.authorize({
+      headers: {
+        authorization: 'Bearer ben@example.com-abc123'
+      }
+    }, function (err, user) {
+      authorizer.end()
+      session.unlock('ben@example.com-abc123')
+      session.delete('ben@example.com-abc123')
+
+      profile.done()
+      t.equal(err, null)
+      t.equal(user.email, 'ben@example.com')
+      t.end()
+    })
+  })
+})
+
+tap.test('does not check github if request is within timeout window', function (t) {
+  var authorizer = new Authorizer()
+
+  session.lock('ben@example.com-abc123')
   session.set('ben@example.com-abc123', userComplete, function (err) {
     t.equal(err, null)
     authorizer.authorize({
@@ -26,8 +51,8 @@ tap.test('it responds with session object if SSO dance is complete', function (t
     }, function (err, user) {
       authorizer.end()
       session.delete('ben@example.com-abc123')
+      session.unlock('ben@example.com-abc123')
 
-      profile.done()
       t.equal(err, null)
       t.equal(user.email, 'ben@example.com')
       t.end()
@@ -50,6 +75,7 @@ tap.test('it returns error with login url if access token is no longer valid', f
     }, function (err, user) {
       authorizer.end()
       session.delete('ben@example.com-abc123')
+      session.unlock('ben@example.com-abc123')
 
       profile.done()
       t.ok(err.message.indexOf('visit https://auth.example.com') !== -1)
@@ -69,6 +95,7 @@ tap.test('it returns error with login url if SSO dance is not complete', functio
     }, function (err, user) {
       authorizer.end()
       session.delete('ben@example.com-abc123')
+      session.unlock('ben@example.com-abc123')
 
       t.ok(err.message.indexOf('visit https://auth.example.com') !== -1)
       t.end()


### PR DESCRIPTION
When a large number of users are performing installs on a server, this results in many upstream requests to GitHub Enterprise or GitHub to check the validity of an auth-token in a short period of time.

With this change we briefly cache the state of a token, so that we don't create this thundering herd problem during an install.
